### PR TITLE
Show number of orders per shop on fetch page

### DIFF
--- a/nginx/html/fetch/index.js
+++ b/nginx/html/fetch/index.js
@@ -102,7 +102,9 @@ const vueapp = new Vue({
 						o.label += ` (<a href='tel:${encodeURI(URInumber)}'>${number}</a>)`;
 						o.html = true;
 					}
-					o.label += `, total: ${o.totalPrice} ct`;
+					if (o.children?.length) {
+						o.label += `(${o.children.length}), total: ${o.totalPrice} ct`;
+					}
 				}
 			});
 		},


### PR DESCRIPTION
As described in the title, this change displays the number of orders on the fetch page, for each shop. It also hides the output of the total price if there are no orders for a given shop (in which case the total price would be zero anyway).